### PR TITLE
Update to documentation and example.py

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,15 +48,15 @@ You will always need to execute commands in the following order:
 
 .. code-block:: python
 
-    from eci import NetStation
-    # Set an IP address for the amplifier as an IPv4 string
-    IP_amp = '10.10.10.42'
-    # Set a port that the amplifier will be listening to as an integer
-    port_amp = 55513
-    ns = NetStation(IP_amp, port_amp)
-    # Set an NTP clock server address as an IPv4 string
-    IP_ntp = '10.10.51'
-    ns.connect(ntp_ip=IP_ntp)
+    from egi_pynetstation import NetStation
+    # Set an IP address for the computer running NetStation as an IPv4 string
+    IP_netstation = '10.10.10.42'
+    # Set a port that NetStation will be listening to as an integer
+    port_ns = 55513
+    ns = NetStation(IP_netstation, port_ns)
+    # Set an NTP clock server (the amplifier) address as an IPv4 string
+    IP_amp = '10.10.51'
+    ns.connect(ntp_ip=IP_amp)
     # Do whatever setup for your experiment here...
     # Begin recording
     ns.begin_rec()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ You will always need to execute commands in the following order:
     port_ns = 55513
     ns = NetStation(IP_netstation, port_ns)
     # Set an NTP clock server (the amplifier) address as an IPv4 string
-    IP_amp = '10.10.51'
+    IP_amp = '10.10.10.51'
     ns.connect(ntp_ip=IP_amp)
     # Do whatever setup for your experiment here...
     # Begin recording

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,10 +50,10 @@ You will always need to execute commands in the following order:
 
     from egi_pynetstation import NetStation
     # Set an IP address for the computer running NetStation as an IPv4 string
-    IP_netstation = '10.10.10.42'
+    IP_ns = '10.10.10.42'
     # Set a port that NetStation will be listening to as an integer
     port_ns = 55513
-    ns = NetStation(IP_netstation, port_ns)
+    ns = NetStation(IP_ns, port_ns)
     # Set an NTP clock server (the amplifier) address as an IPv4 string
     IP_amp = '10.10.10.51'
     ns.connect(ntp_ip=IP_amp)

--- a/example.py
+++ b/example.py
@@ -20,14 +20,17 @@ def main():
     p.add_argument('mode', choices=['local', 'amp'])
     args = p.parse_args()
 
+    # Local mode designed to work with AmpServer Testing Applications
+    # Amp mode for working with the actual EGI Amplifier
+    # If you have the amplifier, you probably want 'amp' mode
     if args.mode == 'local':
         IP = '127.0.0.1'
         IP_amp = '216.239.35.4'
         port = 9885
     elif args.mode == 'amp':
-        IP = '10.10.10.42'
-        IP_amp = '10.10.10.51'
-        port = 55513
+        IP = '10.10.10.42' # IP Address of Net Station
+        IP_amp = '10.10.10.51' # IP Address of Amplifier
+        port = 55513 #Port configured for ECI in Net Station
     else:
         raise RuntimeError('Something strange has occured')
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from eci.NetStation import NetStation
+from egi_pynetstation.NetStation import NetStation
 from time import time
 
 from argparse import ArgumentParser

--- a/example.py
+++ b/example.py
@@ -24,18 +24,23 @@ def main():
     # Amp mode for working with the actual EGI Amplifier
     # If you have the amplifier, you probably want 'amp' mode
     if args.mode == 'local':
-        IP = '127.0.0.1'
-        IP_amp = '216.239.35.4'
-        port = 9885
+        IP_virtual_ns = '127.0.0.1'
+        IP_virtual_amp = '216.239.35.4'
+        port_virtual_ns = 9885
+
+        eci_client = NetStation(IP_virtual_ns, port_virtual_ns)
+        eci_client.connect(ntp_ip=IP_virtual_amp)
     elif args.mode == 'amp':
-        IP = '10.10.10.42' # IP Address of Net Station
+        IP_ns = '10.10.10.42' # IP Address of Net Station
         IP_amp = '10.10.10.51' # IP Address of Amplifier
-        port = 55513 #Port configured for ECI in Net Station
+        port_ns = 55513 #Port configured for ECI in Net Station
+
+        eci_client = NetStation(IP_ns, port_ns)
+        eci_client.connect(ntp_ip=IP_amp)
     else:
         raise RuntimeError('Something strange has occured')
 
-    eci_client = NetStation(IP, port)
-    eci_client.connect(ntp_ip=IP_amp)
+
     eci_client.begin_rec()
     eci_client.send_event(event_type="STRT", start=0.0)
 

--- a/example.py
+++ b/example.py
@@ -23,13 +23,15 @@ def main():
     # Local mode designed to work with AmpServer Testing Applications
     # Amp mode for working with the actual EGI Amplifier
     # If you have the amplifier, you probably want 'amp' mode
+    # The _cmd is what you're sending commands to in python (like NetStation)
+    # the _clock is the virtualized amplifier
     if args.mode == 'local':
-        IP_virtual_ns = '127.0.0.1'
-        IP_virtual_amp = '216.239.35.4'
-        port_virtual_ns = 9885
+        IP_cmd = '127.0.0.1'
+        IP_clock = '216.239.35.4'
+        port_cmd = 9885
 
-        eci_client = NetStation(IP_virtual_ns, port_virtual_ns)
-        eci_client.connect(ntp_ip=IP_virtual_amp)
+        eci_client = NetStation(IP_cmd, port_cmd)
+        eci_client.connect(ntp_ip=IP_clock)
     elif args.mode == 'amp':
         IP_ns = '10.10.10.42' # IP Address of Net Station
         IP_amp = '10.10.10.51' # IP Address of Amplifier


### PR DESCRIPTION
Made updates to example.py and docs to reflect package name change (dev version to now). In general (default) configurations from EGI, the computer running Net Station has the IP 10.10.10.42 and the amplifier has the IP 10.10.10.51.  Within Net Station, you can specify the port for ECI communication; the first port option is 55513, but this must be selected by the user in their setup.

```
IP = '10.10.10.42' # IP Address of Net Station
IP_amp = '10.10.10.51' # IP Address of Amplifier
port = 55513 #Port configured for ECI in Net Station
```