### PR TITLE
update time=float to subtract epoch start

### DIFF
--- a/egi_pynetstation/NetStation.py
+++ b/egi_pynetstation/NetStation.py
@@ -270,7 +270,7 @@ class NetStation(object):
         if start == 'now':
             start = time.time() - self._syncepoch
         elif isinstance(start, float):
-            start = start
+            start = start - self._syncepoch
         else:
             t_start = type(start)
             return TypeError(


### PR DESCRIPTION
Fix bug to correct timing when sending specific float time. Need to subtract out epoch start time. This was correctly implemented in the "now" method, but not in this case of specific time stamp. 